### PR TITLE
Give drag start event object

### DIFF
--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -376,7 +376,7 @@ class Rheostat extends React.Component {
       document.attachEvent('onmouseup', this.endSlide);
     }
 
-    if (this.props.onSliderDragStart) this.props.onSliderDragStart();
+    if (this.props.onSliderDragStart) this.props.onSliderDragStart(ev);
 
     killEvent(ev);
   }
@@ -392,7 +392,7 @@ class Rheostat extends React.Component {
     document.addEventListener('touchmove', this.handleTouchSlide, false);
     document.addEventListener('touchend', this.endSlide, false);
 
-    if (this.props.onSliderDragStart) this.props.onSliderDragStart();
+    if (this.props.onSliderDragStart) this.props.onSliderDragStart(ev);
 
     killEvent(ev);
   }

--- a/test/slider-test.jsx
+++ b/test/slider-test.jsx
@@ -178,7 +178,7 @@ describe('<Slider />', () => {
     const handle = wrapper.find('.rheostat-handle');
     handle.simulate('mouseDown', { clientX: 0, clientY: 0 });
     assert(onSliderDragStart.callCount === 1, 'onDragStart was called from mouseDown');
-    assert(onSliderDragStart.calledWith({ clientX: 0, clientY: 0 }));
+    assert(onSliderDragStart.calledWithMatch({ clientX: 0, clientY: 0 }));
     const touchProps = {
       changedTouches: [
         {
@@ -189,7 +189,7 @@ describe('<Slider />', () => {
     };
     handle.simulate('touchStart', touchProps);
     assert(onSliderDragStart.callCount === 2, 'onDragStart was called from touchStart');
-    assert(onSliderDragStart.calledWith(touchProps));
+    assert(onSliderDragStart.calledWithMatch(touchProps));
   });
 });
 

--- a/test/slider-test.jsx
+++ b/test/slider-test.jsx
@@ -178,6 +178,7 @@ describe('<Slider />', () => {
     const handle = wrapper.find('.rheostat-handle');
     handle.simulate('mouseDown', { clientX: 0, clientY: 0 });
     assert(onSliderDragStart.callCount === 1, 'onDragStart was called from mouseDown');
+    assert(onSliderDragStart.calledWith({ clientX: 0, clientY: 0 }));
     const touchProps = {
       changedTouches: [
         {
@@ -188,6 +189,7 @@ describe('<Slider />', () => {
     };
     handle.simulate('touchStart', touchProps);
     assert(onSliderDragStart.callCount === 2, 'onDragStart was called from touchStart');
+    assert(onSliderDragStart.calledWith(touchProps));
   });
 });
 


### PR DESCRIPTION
Link to upstream PR: https://github.com/airbnb/rheostat/pull/82

Per that pr:
Rheostat already gives the clientX/clientY on handleDrag, but it doesn't give it onSliderDragStart. Unfortunately that means that if the user clicks on a slider, but doesn't move their mouse or finger, then we won't know where the clientX/clientY is.

This is needed because of secret reasons that you guys know about. 📨  🔍 