### PR TITLE
Don't call the onChange handler when new props are given

### DIFF
--- a/lib/Slider.js
+++ b/lib/Slider.js
@@ -719,7 +719,9 @@ var Rheostat = function (_React$Component2) {
             handleDimensions = _state3.handleDimensions;
 
 
-        return Math.max(Math.min(proposedPosition, handlePos[idx + 1] !== undefined ? handlePos[idx + 1] - handleDimensions : SliderConstants.PERCENT_FULL), handlePos[idx - 1] !== undefined ? handlePos[idx - 1] + handleDimensions : SliderConstants.PERCENT_EMPTY);
+        return Math.max(Math.min(proposedPosition, handlePos[idx + 1] !== undefined ? handlePos[idx + 1] - handleDimensions : SliderConstants.PERCENT_FULL // 100% is the highest value
+        ), handlePos[idx - 1] !== undefined ? handlePos[idx - 1] + handleDimensions : SliderConstants.PERCENT_EMPTY // 0% is the lowest value
+        );
       }
 
       return validatePosition;
@@ -825,8 +827,6 @@ var Rheostat = function (_React$Component2) {
             return _this8.props.algorithm.getPosition(value, min, max);
           }),
           values: nextValues
-        }, function () {
-          return _this8.fireChangeEvent();
         });
       }
 

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -586,7 +586,7 @@ class Rheostat extends React.Component {
     this.setState({
       handlePos: nextValues.map(value => this.props.algorithm.getPosition(value, min, max)),
       values: nextValues,
-    }, () => this.fireChangeEvent());
+    });
   }
 
   render() {

--- a/test/slider-test.jsx
+++ b/test/slider-test.jsx
@@ -113,14 +113,13 @@ describe('<Slider />', () => {
     });
 
     it('should update values when we are sliding', () => {
-      const onChange = sinon.spy();
-      const slider = mount(<Slider onChange={onChange} values={[0]} />);
+      const slider = mount(<Slider values={[0]} />);
 
       slider.setState({ slidingIndex: 0 });
 
       slider.setProps({ values: [50] });
 
-      assert(onChange.callCount === 1, 'updateNewValues was called');
+      assert.include(slider.state('values'), 50, 'values was updated');
     });
 
     it('should not update values if they are the same', () => {
@@ -137,8 +136,6 @@ describe('<Slider />', () => {
       const slider = mount(<Slider onChange={onChange} values={[50]} />);
 
       slider.setProps({ values: [80] });
-
-      assert.isTrue(onChange.calledOnce, 'updateNewValues was called');
 
       assert.include(slider.state('values'), 80, 'new value is reflected in state');
     });


### PR DESCRIPTION
Our patch to allow us to treat rheostat as a controlled component resulted in the onChange handler getting called when rheostat received new props during drag.  This originally didn't effect us because we actually use onValuesUpdated, not onChange.

This change stops calling onChange when new props are given (it doesn't make sense for a controlled component anyways - they should only fire when an event is fired from within rheostat).